### PR TITLE
Totals row troubleshooting

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -87,8 +87,8 @@ function hourlySum() {
   th.textContent = 'Hourly sum';
   tr.append(th);
   var hourlySubTotal = [];
-  var hourlyTotal = 0;
   for (var j = 0; j < hoursPerDay.length; j++) {
+    var hourlyTotal = 0;
     for (var i = 0; i < hourlySumArr.length; i++) {
       hourlyTotal += hourlySumArr[i].hourNums[j];
     }
@@ -103,9 +103,8 @@ function hourlySum() {
 // updates footer
 function updateTfoot() {
   var hourlySubTotal = [];
-  var hourlyTotal = 0;
   for (var j = 0; j < hoursPerDay.length; j++) {
-    // var reference = 'td' + j;
+    var hourlyTotal = 0;
     for (var i = 0; i < hourlySumArr.length; i++) {
       hourlyTotal += hourlySumArr[i].hourNums[j];
     }

--- a/js/app.js
+++ b/js/app.js
@@ -2,7 +2,7 @@
 
 var hoursPerDay = ['6am', '7am', '8am', '9am', '10am', '11am', '12pm', '1pm', '2pm', '3pm', '4pm', '5pm', '6pm', '7pm', 'Total'];
 
-// table creation
+// Creates table
 
 var main = document.getElementById('main');
 var article = document.createElement('article');
@@ -25,7 +25,7 @@ for (var i = 0; i <= hoursPerDay.length - 1; i++) {
 table.append(tbody);
 
 var hourlySumArr = [];
-// Creation of object
+// Prepares to create object
 function ObjectCreation(min, max, ave, city) {
   this.minCust = min;
   this.maxCust = max;
@@ -70,14 +70,14 @@ ObjectCreation.prototype.fillTable = function () {
   tr.append(td);
 };
 
-
-
+// Creates objects
 var Seattle = new ObjectCreation(23, 65, 6.3, 'Seattle');
 var Tokyo = new ObjectCreation(3, 24, 1.2, 'Tokyo');
 var Dubai = new ObjectCreation(11, 38, 3.7, 'Dubai');
 var Paris = new ObjectCreation(20, 38, 2.3, 'Paris');
 var Lima = new ObjectCreation(2, 16, 4.6, 'Lima');
 
+// creates hourly sum row in tfoot
 var tfoot = document.createElement('tfoot');
 table.append(tfoot);
 function hourlySum() {
@@ -94,42 +94,29 @@ function hourlySum() {
     }
     hourlySubTotal.push(hourlyTotal);
     var td = document.createElement('td');
+    td.setAttribute('id', 'update' + j);
     td.textContent = hourlySubTotal[j];
     tr.append(td);
   }
 }
 
-// replace footer
-function hourlySumReplacement() {
-  tfoot.remove();
-  var tfooter = document.createElement('tfoot');
-  table.append(tfooter);
-  var tr = document.createElement('tr');
-  tfooter.append(tr);
-  var th = document.createElement('th');
-  th.textContent = 'Hourly sum';
-  tr.append(th);
+// updates footer
+function updateTfoot() {
   var hourlySubTotal = [];
   var hourlyTotal = 0;
   for (var j = 0; j < hoursPerDay.length; j++) {
+    // var reference = 'td' + j;
     for (var i = 0; i < hourlySumArr.length; i++) {
       hourlyTotal += hourlySumArr[i].hourNums[j];
     }
     hourlySubTotal.push(hourlyTotal);
-    var td = document.createElement('td');
-    td.textContent = hourlySubTotal[j];
-    tr.append(td);
+    document.getElementById('update' + j).innerHTML = hourlySubTotal[j];
   }
-
 }
 
-// delete footer to add last row and call footer again
-
-// }
 // uses form to create object
 var listener = document.getElementById('submit');
 listener.addEventListener('submit', useForm);
-
 function useForm(event) {
   event.preventDefault();
   var nameInput = event.target.city.value;
@@ -137,6 +124,7 @@ function useForm(event) {
   var maxInput = event.target.maxcust.value;
   var aveInput = event.target.aveorder.value;
   new ObjectCreation(minInput, maxInput, aveInput, nameInput);
-  hourlySumReplacement();
+  updateTfoot();
+  // hourlySumReplacement();
 }
 hourlySum();


### PR DESCRIPTION
// hour totals row replacement was as simple as inhtml on each td. I had the idea yesterday but tried something else first and forgot about it.
// hourly totals error was that each td of tfoot was adding the hourly sales (for that hour) of each store, then adding that sum to the sum of the previous hour and posting that sum to the td. The fix was to move var `hourlyTotal = 0;` inside the outer for loop in the functions titled, "hourlySum" and "hourlySumReplacement". This set the variable back to 0 at the start of each column so each td is adding the sum of the numbers in its column to 0 instead of the sum of the previous column. This was definitely an interesting find though. i'm sure that error could come in handy later if used intentionally.